### PR TITLE
Include forced photometry

### DIFF
--- a/lightcurve_step/step.py
+++ b/lightcurve_step/step.py
@@ -45,7 +45,7 @@ class LightcurveStep(GenericStep):
         query_non_detections = self.db_client.query(NonDetection)
         query_forced_photometries = self.db_client.query(ForcedPhotometry)
 
-        # TODO: when using clean DB addFields step should be: {$addFields: {"candid": "$_id"}}
+        # TODO: when using clean DB addFields step should be: {$addFields: {"candid": "$_id", "forced": False}}
         db_detections = query_detections.collection.aggregate(
             [
                 {"$match": {"aid": {"$in": list(messages["aids"])}}},
@@ -94,11 +94,11 @@ class LightcurveStep(GenericStep):
         db_non_detections = query_non_detections.collection.find(
             {"aid": {"$in": list(messages["aids"])}}, {"_id": False}
         )
-        # TODO: Add ra, dec, e_ra, e_dec
+
         db_forced_photometries = query_forced_photometries.collection.aggregate(
             [
                 {"$match": {"aid": {"$in": list(messages["aids"])}}},
-                {"$addFields": {"candid": "$_id"}},
+                {"$addFields": {"candid": "$_id", "forced": False}},
                 {"$project": {"_id": False}},
             ]
         )

--- a/lightcurve_step/step.py
+++ b/lightcurve_step/step.py
@@ -104,7 +104,9 @@ class LightcurveStep(GenericStep):
             ]
         )
 
-        detections = pd.DataFrame(messages["detections"] + list(db_detections) + list(db_forced_photometries))
+        detections = pd.DataFrame(
+            messages["detections"] + list(db_detections) + list(db_forced_photometries)
+        )
         non_detections = pd.DataFrame(
             messages["non_detections"] + list(db_non_detections)
         )

--- a/lightcurve_step/step.py
+++ b/lightcurve_step/step.py
@@ -79,7 +79,7 @@ class LightcurveStep(GenericStep):
                                 "else": None,
                             }
                         },
-                        "forced":  False,
+                        "forced": False,
                         "new": False,
                     }
                 },

--- a/lightcurve_step/step.py
+++ b/lightcurve_step/step.py
@@ -72,13 +72,6 @@ class LightcurveStep(GenericStep):
                                 "else": True,
                             }
                         },
-                        "forced": {
-                            "$cond": {
-                                "if": "$forced",
-                                "then": "$forced",
-                                "else": False,
-                            }
-                        },
                         "parent_candid": {
                             "$cond": {
                                 "if": "$parent_candid",
@@ -86,6 +79,7 @@ class LightcurveStep(GenericStep):
                                 "else": None,
                             }
                         },
+                        "forced":  False,
                         "new": False,
                     }
                 },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 apf_base~=2.1.5
-git+https://github.com/alercebroker/db-plugins@4.1.1
+git+https://github.com/alercebroker/db-plugins@4.2.0

--- a/schema.avsc
+++ b/schema.avsc
@@ -80,6 +80,18 @@
             "type": "boolean"
           },
           {
+            "name": "forced",
+            "type": "boolean"
+          },
+          {
+            "name": "new",
+            "type": "boolean"
+          },
+          {
+            "name": "parent_candid",
+            "type": ["long", "string", "null"]
+          },
+          {
             "name": "extra_fields",
             "type": {
               "default": {},

--- a/tests/integration/input_schema.avsc
+++ b/tests/integration/input_schema.avsc
@@ -80,6 +80,14 @@
             "type": "boolean"
           },
           {
+            "name": "forced",
+            "type": "boolean"
+          },
+          {
+            "name": "parent_candid",
+            "type": ["long", "string", "null"]
+          },
+          {
             "name": "extra_fields",
             "type": {
               "default": {},


### PR DESCRIPTION
Lee de la fotometría forzada.

Incluye un flag `new` en el output para identificar detecciones nuevas de las que vienen en la base de datos para controlar el volumen de escritura en el paso de correcciones